### PR TITLE
fix: refactors reveal pipe  to use flex position

### DIFF
--- a/src/RevealPipe.styles.ts
+++ b/src/RevealPipe.styles.ts
@@ -3,7 +3,6 @@ import { breakpoints } from "./style-vars";
 
 export const RevealPipeContainer = styled.div<{
   $isActive: boolean;
-  $isMobile: boolean;
 }>`
   display: flex;
   flex-direction: column;

--- a/src/RevealPipe.styles.ts
+++ b/src/RevealPipe.styles.ts
@@ -3,7 +3,13 @@ import { breakpoints } from "./style-vars";
 
 export const RevealPipeContainer = styled.div<{
   $isActive: boolean;
+  $isMobile: boolean;
 }>`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+
   button {
     background-color: transparent;
     border: none;
@@ -28,7 +34,6 @@ export const RevealPipeContainer = styled.div<{
     transform: rotate(180deg) scaleX(-1);
     position: relative;
     top: -16px;
-    left: 6px;
 
     @media (max-width: ${breakpoints.SM}) {
       top: -45px;

--- a/src/RevealPipe.tsx
+++ b/src/RevealPipe.tsx
@@ -11,15 +11,30 @@ export type RevealPipeProps = {
   handleClick: (pipe: PipeName) => void;
 };
 
+const isMobile = () => {
+  if (
+    /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
+      navigator.userAgent
+    )
+  ) {
+    return true;
+  } else {
+    return false;
+  }
+};
+
 export const RevealPipe = ({
   pipeName,
   pipeColor,
   isActive,
   handleClick,
 }: RevealPipeProps): React.ReactElement => {
+  console.log("isMobile", isMobile());
+  console.log("userAgent", navigator.userAgent);
   return (
     <RevealPipeContainer
       $isActive={isActive}
+      $isMobile={isMobile()}
       onClick={() => handleClick(pipeName)}
     >
       <button

--- a/src/RevealPipe.tsx
+++ b/src/RevealPipe.tsx
@@ -11,30 +11,17 @@ export type RevealPipeProps = {
   handleClick: (pipe: PipeName) => void;
 };
 
-const isMobile = () => {
-  if (
-    /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
-      navigator.userAgent
-    )
-  ) {
-    return true;
-  } else {
-    return false;
-  }
-};
-
 export const RevealPipe = ({
   pipeName,
   pipeColor,
   isActive,
   handleClick,
 }: RevealPipeProps): React.ReactElement => {
-  console.log("isMobile", isMobile());
+  console.log("isMobile");
   console.log("userAgent", navigator.userAgent);
   return (
     <RevealPipeContainer
       $isActive={isActive}
-      $isMobile={isMobile()}
       onClick={() => handleClick(pipeName)}
     >
       <button

--- a/src/RevealPipe.tsx
+++ b/src/RevealPipe.tsx
@@ -17,8 +17,6 @@ export const RevealPipe = ({
   isActive,
   handleClick,
 }: RevealPipeProps): React.ReactElement => {
-  console.log("isMobile");
-  console.log("userAgent", navigator.userAgent);
   return (
     <RevealPipeContainer
       $isActive={isActive}


### PR DESCRIPTION
This pull request includes changes to the `src/RevealPipe.styles.ts` and `src/RevealPipe.tsx` files to improve the styling and debugging of the `RevealPipe` component. The most important changes include adding flexbox properties to the `RevealPipeContainer`, modifying the `left` property in a media query, and adding console log statements for debugging purposes.

Styling improvements:

* [`src/RevealPipe.styles.ts`](diffhunk://#diff-f768a3a506fa22e73f84d32ac954b258404dae50ffaf8261874da7191900f405R7-R11): Added flexbox properties (`display: flex`, `flex-direction: column`, `align-items: center`, and `justify-content: center`) to the `RevealPipeContainer` to enhance layout alignment.
* [`src/RevealPipe.styles.ts`](diffhunk://#diff-f768a3a506fa22e73f84d32ac954b258404dae50ffaf8261874da7191900f405L31): Removed the `left` property from the `button` element within the `RevealPipeContainer`.