### PR TITLE
fix: rolls back line height change

### DIFF
--- a/src/global-styles.ts
+++ b/src/global-styles.ts
@@ -101,7 +101,6 @@ table {
 
     @media (max-width: ${breakpoints.SM}) {
         p, li, a {
-            line-height: 1.25;
             font-size: 14px; /* Adjust for smaller screens */
             margin-bottom: 1em; /* Reduce spacing */
             font-weight: 400; 


### PR DESCRIPTION
This pull request includes a small change to the `src/global-styles.ts` file. The change removes the `line-height` property from the `p, li, a` elements within the media query for smaller screens.